### PR TITLE
Refactor: Split the bullet splitting methods into helpers

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -34,7 +34,7 @@ export default class NoteRefactor extends Plugin {
     console.log("Loading Note Refactor plugin");
     this.settings = Object.assign(
       new NoteRefactorSettings(),
-      await this.loadData()
+      await this.loadData(),
     );
     this.momentDateRegex = new MomentDateRegex();
     this.vault = this.app.vault;
@@ -48,7 +48,7 @@ export default class NoteRefactor extends Plugin {
       name: "Extract selection to new note - first line as file name",
       callback: () =>
         this.editModeGuard(
-          async () => await this.extractSelectionFirstLine("replace-selection")
+          async () => await this.extractSelectionFirstLine("replace-selection"),
         ),
       hotkeys: [
         {
@@ -63,7 +63,7 @@ export default class NoteRefactor extends Plugin {
       name: "Extract selection to new note - content only",
       callback: () =>
         this.editModeGuard(() =>
-          this.extractSelectionContentOnly("replace-selection")
+          this.extractSelectionContentOnly("replace-selection"),
         ),
       hotkeys: [
         {
@@ -78,7 +78,7 @@ export default class NoteRefactor extends Plugin {
       name: "Extract selection to new note - only prefix as file name",
       callback: () =>
         this.editModeGuard(() =>
-          this.extractSelectionAutogenerate("replace-selection")
+          this.extractSelectionAutogenerate("replace-selection"),
         ),
     });
 
@@ -126,7 +126,7 @@ export default class NoteRefactor extends Plugin {
       name: "Split selected bullet points - prefix as file name",
       callback: () =>
         this.editModeGuard(
-          async () => await this.splitSelectedBulletPointsUsingPrefix()
+          async () => await this.splitSelectedBulletPointsUsingPrefix(),
         ),
     });
 
@@ -135,7 +135,7 @@ export default class NoteRefactor extends Plugin {
       name: "Split selected bullet points - content only",
       callback: () =>
         this.editModeGuard(
-          async () => await this.splitSelectedBulletPointsContentOnly()
+          async () => await this.splitSelectedBulletPointsContentOnly(),
         ),
     });
 
@@ -148,21 +148,10 @@ export default class NoteRefactor extends Plugin {
       new Notice("No active Markdown view.");
       return;
     }
-    const doc = mdView.editor;
+    const editor = mdView.editor;
 
-    const selectedLines = this.NRDoc.selectedContent(doc);
-    if (selectedLines.length === 0) {
-      new Notice("No text selected.");
-      return;
-    }
-
-    const bulletNotes = this.NRDoc.splitSelectedBulletPoints(
-      selectedLines,
-      BULLET_POINT_REGEX
-    );
-
-    if (bulletNotes.length === 0) {
-      new Notice("No bullet points found in the selection to split.");
+    const bulletNotes = this.getValidatedBulletPointSelection(mdView);
+    if (!bulletNotes) {
       return;
     }
 
@@ -174,14 +163,14 @@ export default class NoteRefactor extends Plugin {
         dedupedFileNames[i],
         noteLines,
         mdView,
-        doc,
+        editor,
         "replace-selection",
-        true
+        true,
       );
     }
 
     new Notice(
-      `Successfully split ${bulletNotes.length} notes from bullet points.`
+      `Successfully split ${bulletNotes.length} notes from bullet points.`,
     );
   }
 
@@ -192,27 +181,107 @@ export default class NoteRefactor extends Plugin {
       new Notice("No active Markdown view.");
       return;
     }
-    // const doc = mdView.editor; // doc is not directly used here anymore for content replacement
 
-    const selectedLines = this.NRDoc.selectedContent(mdView.editor);
-    if (selectedLines.length === 0) {
-      new Notice("No text selected.");
-      return;
-    }
-
-    const bulletNotes = this.NRDoc.splitSelectedBulletPoints(
-      selectedLines,
-      BULLET_POINT_REGEX
-    );
-    if (bulletNotes.length === 0) {
-      new Notice("No bullet points found in the selection to split.");
+    const bulletNotes = this.getValidatedBulletPointSelection(mdView);
+    if (!bulletNotes) {
       return;
     }
 
     const basePrefix = this.file.fileNamePrefix();
+
+    const dedupedFileNames = this.generatePrefixedFileNames(
+      bulletNotes,
+      basePrefix,
+    );
+    if (dedupedFileNames.length === 0) {
+      return;
+    }
+
+    const createdCount = await this.createNotesFromBulletsAndReplaceLinks(
+      mdView,
+      bulletNotes,
+      dedupedFileNames,
+      false, // isContentOnly for _createNoteFromBulletItem
+    );
+
+    if (createdCount > 0) {
+      new Notice(
+        `Successfully split and created ${createdCount} notes using prefix "${basePrefix}".`,
+      );
+    }
+  }
+
+  // Refactored method using the new helper
+  async splitSelectedBulletPointsContentOnly(): Promise<void> {
+    const mdView = this.app.workspace.activeLeaf.view as MarkdownView;
+    if (!mdView) {
+      new Notice("No active Markdown view.");
+      return;
+    }
+
+    const bulletNotes = this.getValidatedBulletPointSelection(mdView);
+    if (!bulletNotes) {
+      return;
+    }
+
+    const basePrefix = this.file.fileNamePrefix();
+
+    const dedupedFileNames = this.generatePrefixedFileNames(
+      bulletNotes,
+      basePrefix,
+    );
+    if (dedupedFileNames.length === 0) {
+      return;
+    }
+
+    const createdCount = await this.createNotesFromBulletsAndReplaceLinks(
+      mdView,
+      bulletNotes,
+      dedupedFileNames,
+      true, // isContentOnly for _createNoteFromBulletItem
+    );
+
+    if (createdCount > 0) {
+      new Notice(
+        `Successfully split and created ${createdCount} notes (content only) using prefix "${basePrefix}".`,
+      );
+    }
+  }
+
+  private getValidatedBulletPointSelection(
+    mdView: MarkdownView,
+  ): string[][] | null {
+    if (!mdView) {
+      new Notice("No active Markdown view provided.");
+      return null;
+    }
+
+    const editor = mdView.editor;
+    const selectedLines = this.NRDoc.selectedContent(editor);
+    if (selectedLines.length === 0) {
+      new Notice("No text selected.");
+      return null;
+    }
+
+    const bulletNotes = this.NRDoc.splitSelectedBulletPoints(
+      selectedLines,
+      BULLET_POINT_REGEX,
+    );
+
+    if (bulletNotes.length === 0) {
+      new Notice("No bullet points found in the selection to split.");
+      return null;
+    }
+    return bulletNotes;
+  }
+
+  private generatePrefixedFileNames(
+    bulletNotes: string[][],
+    basePrefix: string,
+  ): string[] {
     if (!basePrefix && basePrefix !== "") {
       new Notice("File name prefix is not properly configured in settings.");
-      return;
+      return [];
     }
 
     const fileNameCandidates: string[] = [];
@@ -220,12 +289,13 @@ export default class NoteRefactor extends Plugin {
       if (basePrefix) {
         if (i > 0) {
           fileNameCandidates.push(
-            this.file.sanitisedFileName(`${basePrefix}-${i + 1}`)
+            this.file.sanitisedFileName(`${basePrefix}-${i + 1}`),
           );
         } else {
           fileNameCandidates.push(this.file.sanitisedFileName(`${basePrefix}`));
         }
       } else {
+        // If basePrefix is an empty string, name files "1", "2", ...
         fileNameCandidates.push(this.file.sanitisedFileName(`${i + 1}`));
       }
     }
@@ -233,9 +303,17 @@ export default class NoteRefactor extends Plugin {
     const dummyNotesForNaming: string[][] = fileNameCandidates.map((name) => [
       name,
     ]);
-    const dedupedFileNames =
-      this.file.ensureUniqueFileNames(dummyNotesForNaming);
+    return this.file.ensureUniqueFileNames(dummyNotesForNaming);
+  }
+
+  private async createNotesFromBulletsAndReplaceLinks(
+    mdView: MarkdownView,
+    bulletNotes: string[][],
+    dedupedFileNames: string[],
+    isContentOnly: boolean, // isContentOnly for _createNoteFromBulletItem
+  ): Promise<number> {
     let createdCount = 0;
+    const editor = mdView.editor;
 
     for (let i = 0; i < bulletNotes.length; i++) {
       const noteLines = bulletNotes[i];
@@ -244,8 +322,8 @@ export default class NoteRefactor extends Plugin {
         currentFilename,
         noteLines,
         mdView,
-        false
-      ); // isContentOnly = false
+        isContentOnly,
+      );
 
       if (filePath && this.settings.openNewNote) {
         const leaf = this.app.workspace.getLeaf("split", "vertical");
@@ -259,10 +337,8 @@ export default class NoteRefactor extends Plugin {
       }
     }
 
-    // Replace the original selection with links to all created notes
     if (createdCount > 0) {
-      const doc = mdView.editor;
-      const selectedText = doc.getSelection();
+      // Replace the original selection with links to all created notes
       const createdLinks = await Promise.all(
         dedupedFileNames.slice(0, createdCount).map(async (fileName, index) => {
           const filePath = this.obsFile.filePathAndFileName(fileName, mdView);
@@ -276,144 +352,33 @@ export default class NoteRefactor extends Plugin {
               fileName,
               link,
               filePath,
-              bulletNotes[index].join("\n")
+              bulletNotes[index].join("\n"),
             );
           }
           return "";
-        })
+        }),
       );
 
       const replacementText = createdLinks.filter((link) => link).join("\n");
       if (replacementText) {
-        doc.replaceSelection(replacementText);
+        editor.replaceSelection(replacementText);
       }
     }
-
-    new Notice(
-      `Successfully split and created ${createdCount} notes using prefix "${basePrefix}".`
-    );
-  }
-
-  // Refactored method using the new helper
-  async splitSelectedBulletPointsContentOnly(): Promise<void> {
-    const mdView = this.app.workspace.activeLeaf.view as MarkdownView;
-    if (!mdView) {
-      new Notice("No active Markdown view.");
-      return;
-    }
-
-    const selectedLines = this.NRDoc.selectedContent(mdView.editor);
-    if (selectedLines.length === 0) {
-      new Notice("No text selected.");
-      return;
-    }
-
-    const bulletNotes = this.NRDoc.splitSelectedBulletPoints(
-      selectedLines,
-      BULLET_POINT_REGEX
-    );
-    if (bulletNotes.length === 0) {
-      new Notice("No bullet points found in the selection to split.");
-      return;
-    }
-
-    const basePrefix = this.file.fileNamePrefix();
-    if (!basePrefix && basePrefix !== "") {
-      new Notice("File name prefix is not properly configured in settings.");
-      return;
-    }
-
-    const fileNameCandidates: string[] = [];
-    for (let i = 0; i < bulletNotes.length; i++) {
-      if (basePrefix) {
-        if (i > 0) {
-          fileNameCandidates.push(
-            this.file.sanitisedFileName(`${basePrefix}-${i + 1}`)
-          );
-        } else {
-          fileNameCandidates.push(this.file.sanitisedFileName(`${basePrefix}`));
-        }
-      } else {
-        fileNameCandidates.push(this.file.sanitisedFileName(`${i + 1}`));
-      }
-    }
-
-    const dummyNotesForNaming: string[][] = fileNameCandidates.map((name) => [
-      name,
-    ]);
-    const dedupedFileNames =
-      this.file.ensureUniqueFileNames(dummyNotesForNaming);
-    let createdCount = 0;
-
-    for (let i = 0; i < bulletNotes.length; i++) {
-      const noteLines = bulletNotes[i];
-      const currentFilename = dedupedFileNames[i];
-      const filePath = await this._createNoteFromBulletItem(
-        currentFilename,
-        noteLines,
-        mdView,
-        true
-      ); // isContentOnly = true
-
-      if (filePath && this.settings.openNewNote && i === 0) {
-        const leaf = this.app.workspace.getLeaf("split", "vertical");
-        const file = this.app.vault.getAbstractFileByPath(filePath);
-        if (file instanceof TFile) {
-          await leaf.openFile(file);
-        }
-      }
-      if (filePath) {
-        createdCount++;
-      }
-    }
-
-    // Replace the original selection with links to all created notes
-    if (createdCount > 0) {
-      const doc = mdView.editor;
-      const selectedText = doc.getSelection();
-      const createdLinks = await Promise.all(
-        dedupedFileNames.slice(0, createdCount).map(async (fileName, index) => {
-          const filePath = this.obsFile.filePathAndFileName(fileName, mdView);
-          if (filePath) {
-            const link = await this.NRDoc.markdownLink(filePath);
-            return this.NRDoc.templatedContent(
-              link,
-              this.settings.noteLinkTemplate,
-              mdView.file.basename,
-              await this.NRDoc.markdownLink(mdView.file.path),
-              fileName,
-              link,
-              filePath,
-              bulletNotes[index].join("\n")
-            );
-          }
-          return "";
-        })
-      );
-
-      const replacementText = createdLinks.filter((link) => link).join("\n");
-      if (replacementText) {
-        doc.replaceSelection(replacementText);
-      }
-    }
-
-    new Notice(
-      `Successfully split and created ${createdCount} notes (content only) using prefix "${basePrefix}".`
-    );
+    return createdCount;
   }
 
   private async _createNoteFromBulletItem(
     fileName: string,
     noteItemLines: string[],
     mdView: MarkdownView,
-    isContentOnly: boolean
+    isContentOnly: boolean,
   ): Promise<string | null> {
     const header = noteItemLines[0] || "";
     const contentArr = noteItemLines.slice(1);
     const originalNote = this.NRDoc.noteContent(
       header,
       contentArr,
-      isContentOnly
+      isContentOnly,
     );
     let noteContent = originalNote;
 
@@ -432,7 +397,7 @@ export default class NoteRefactor extends Plugin {
           mdView.file,
           "",
           "",
-          ""
+          "",
         );
         const newNoteLink = await this.NRDoc.markdownLink(filePath);
         noteContent = this.NRDoc.templatedContent(
@@ -443,7 +408,7 @@ export default class NoteRefactor extends Plugin {
           fileName,
           newNoteLink,
           filePath,
-          noteContent
+          noteContent,
         );
       }
 
@@ -452,7 +417,7 @@ export default class NoteRefactor extends Plugin {
     } catch (error) {
       console.error(
         `Error creating note from bullet item "${fileName}":`,
-        error
+        error,
       );
       new Notice(`Error creating note: ${fileName}`);
       return null;
@@ -485,7 +450,7 @@ export default class NoteRefactor extends Plugin {
         mdView,
         doc,
         "replace-headings",
-        true
+        true,
       );
     }
   }
@@ -511,7 +476,7 @@ export default class NoteRefactor extends Plugin {
       mdView,
       doc,
       mode,
-      false
+      false,
     );
   }
 
@@ -535,7 +500,7 @@ export default class NoteRefactor extends Plugin {
       mdView,
       doc,
       mode,
-      true
+      true,
     );
   }
 
@@ -544,7 +509,7 @@ export default class NoteRefactor extends Plugin {
     mdView: MarkdownView,
     doc: Editor,
     mode: ReplaceMode,
-    isMultiple: boolean
+    isMultiple: boolean,
   ) {
     const header = selectedContent[0] || "";
     const contentArr = selectedContent.slice(1);
@@ -562,7 +527,7 @@ export default class NoteRefactor extends Plugin {
         mdView.file,
         "",
         "",
-        ""
+        "",
       );
       const newNoteLink = await this.NRDoc.markdownLink(filePath);
       note = this.NRDoc.templatedContent(
@@ -573,7 +538,7 @@ export default class NoteRefactor extends Plugin {
         fileName,
         newNoteLink,
         filePath,
-        note
+        note,
       );
     }
 
@@ -585,7 +550,7 @@ export default class NoteRefactor extends Plugin {
       mdView.file,
       note,
       originalNote,
-      mode
+      mode,
     );
     if (!isMultiple && this.settings.openNewNote) {
       const leaf = this.app.workspace.getLeaf("split", "vertical");
@@ -602,7 +567,7 @@ export default class NoteRefactor extends Plugin {
     mdView: MarkdownView,
     doc: Editor,
     mode: ReplaceMode,
-    isMultiple: boolean
+    isMultiple: boolean,
   ) {
     const originalHeader = selectedContent[0] || "";
     const contentArr = selectedContent.slice(1);
@@ -620,7 +585,7 @@ export default class NoteRefactor extends Plugin {
         mdView.file,
         "",
         "",
-        ""
+        "",
       );
       const newNoteLink = await this.NRDoc.markdownLink(filePath);
       note = this.NRDoc.templatedContent(
@@ -631,7 +596,7 @@ export default class NoteRefactor extends Plugin {
         fileName,
         newNoteLink,
         filePath,
-        note
+        note,
       );
     }
 
@@ -643,7 +608,7 @@ export default class NoteRefactor extends Plugin {
       mdView.file,
       note,
       originalNote,
-      mode
+      mode,
     );
     if (!isMultiple && this.settings.openNewNote) {
       const leaf = this.app.workspace.getLeaf("split", "vertical");
@@ -684,7 +649,7 @@ export default class NoteRefactor extends Plugin {
       this.obsFile,
       note,
       doc,
-      mode
+      mode,
     );
     new NoteRefactorModal(this.app, modalCreation).open();
   }


### PR DESCRIPTION
…that! Here's a refined version:

Refactor: Comprehensive improvements to bullet point splitting

This commit culminates a series of refactorings aimed at improving the clarity, maintainability, and consistency of the bullet point splitting functionality in `src/main.ts`.

Key changes include:

1.  **Extraction of Helper Functions:**
    *   I extracted common logic from `splitSelectedBulletPoints`, `splitSelectedBulletPointsUsingPrefix`, and `splitSelectedBulletPointsContentOnly` into several private helper functions:
        *   `getValidatedBulletPointSelection`: This handles initial validation (active view, selection, presence of bullets) and retrieves bullet point data. I later refined its signature to accept `mdView: MarkdownView` for cleaner call sites.
        *   `generatePrefixedFileNames`: This generates unique, prefixed file names.
        *   `createNotesFromBulletsAndReplaceLinks`: This manages note creation (via `_createNoteFromBulletItem`), linking, and replacement of your original selection.

2.  **Improved Consistency and Reduced Boolean Flag Misuse:**
    *   **Note Opening:** I corrected logic in `createNotesFromBulletsAndReplaceLinks` to ensure that all newly created notes are opened if your `openNewNote` setting is true, regardless of the specific bullet splitting command you used.
    *   **Notice Handling:** I refactored notice message generation. The `createNotesFromBulletsAndReplaceLinks` helper was made more generic by removing its specific notice logic and `basePrefix` parameter. The calling methods (`splitSelectedBulletPointsUsingPrefix` and `splitSelectedBulletPointsContentOnly`) now display their own context-specific success notices using a `createdCount` returned by the helper. The `isContentOnly` boolean is still passed to `_createNoteFromBulletItem` where it's essential for determining note content formatting via `NRDoc.noteContent`, but it no longer dictates other behaviors in higher-level helpers.

3.  **Code Cleanup:**
    *   I removed numerous temporary and conversational inline comments that were added during the iterative refactoring process.
    *   I applied consistent code formatting using Prettier to the entirety of `src/main.ts`.

These changes result in a more modular, readable, and maintainable codebase for the bullet point splitting features, with clearer separation of concerns and more robust helper functions.